### PR TITLE
Added site.url instead of relying on root

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+url: http://phpne.org.uk
 google_analytics_id: UA-46863902-1
 google_api_key: AIzaSyDnkQrvUL1pFX9pEYnptILZ4PfWoqegMKQ
 paginate: 10

--- a/_includes/open-graph.html
+++ b/_includes/open-graph.html
@@ -1,8 +1,8 @@
     <meta property="og:site_name" content="PHP North East" />
-    <meta property="og:url" content="{{ root }}{{ page.url }}" />
+    <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
     <meta property="og:title" content="{{ page.title }}" />
     <meta property="og:type" content="{% if page.open_graph_type %}{{ page.open_graph_type }}{% else %}website{% endif %}" />
-    <meta property="og:image" content="{% if page.image %}{{ page.image }}{% else %}{{ root }}/img/logo.png{% endif %}" />
+    <meta property="og:image" content="{% if page.image %}{{ page.image }}{% else %}{{ site.url }}/img/logo.png{% endif %}" />
 {% if meta_description %}
     <meta property="og:description" content="{{ meta_description }}" />
 {% endif %}

--- a/_includes/twitter-card.html
+++ b/_includes/twitter-card.html
@@ -5,6 +5,6 @@
 {% if meta_description %}
     <meta name="twitter:description" content="{{ meta_description }}" />
 {% endif %}
-    <meta name="twitter:image:src" content="{% if page.image %}{{ page.image }}{% else %}{{ root }}/img/logo.png{% endif %}" />
+    <meta name="twitter:image:src" content="{% if page.image %}{{ page.image }}{% else %}{{ site.url }}/img/logo.png{% endif %}" />
     <meta name="twitter:domain" content="phpne.org.uk" />
 {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,3 @@
-{% capture root %}http://{{ site.host }}{% if site.port != '80' %}:{{ site.port }}{% endif %}{% endcapture %}
 <!DOCTYPE html>
 <html lang="en-GB" prefix="og: http://ogp.me/ns#">
   <head>


### PR DESCRIPTION
If the site is built locally then pushed the urls will use http://0.0.0.0:4000 (or other local development interface/port). Hardcoding the URL in the _config.yml means that url will always be used regardless of environment.
