### PR TITLE
Added excerpt as description to Open Graph and Twitter Card meta data

### DIFF
--- a/_includes/open-graph.html
+++ b/_includes/open-graph.html
@@ -3,6 +3,4 @@
     <meta property="og:title" content="{{ page.title }}" />
     <meta property="og:type" content="{% if page.open_graph_type %}{{ page.open_graph_type }}{% else %}website{% endif %}" />
     <meta property="og:image" content="{% if page.image %}{{ page.image }}{% else %}{{ site.url }}/img/logo.png{% endif %}" />
-{% if meta_description %}
-    <meta property="og:description" content="{{ meta_description }}" />
-{% endif %}
+    <meta property="og:description" content="{{ page.excerpt|strip_html }}" />

--- a/_includes/twitter-card.html
+++ b/_includes/twitter-card.html
@@ -2,9 +2,7 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@phpne" />
     <meta name="twitter:title" content="{{ page.title }}" />
-    {% if meta_description %}
-    <meta name="twitter:description" content="{{ meta_description }}" />
-    {% endif %}
-    <meta name="twitter:image:src" content="{% if page.image %}{{ page.image }}{% else %}{{ site.url }}/img/logo.png{% endif %}" />
+    <meta name="twitter:description" content="{{ page.excerpt|strip_html }}" />
+    <meta name="twitter:image:src" content="{{ site.url }}/img/logo.png" />
     <meta name="twitter:domain" content="phpne.org.uk" />
 {% endif %}


### PR DESCRIPTION
Instead of checking for a `meta_description` key in post Front Matter and using that for the description in Open Graph and Twitter Card meta data, I’m instead using the post’s excerpt, which is automatically generated by Jekyll and doesn’t require a post author to remember to define a `meta_description` key.

Also done as the `<meta name="twitter:description" />` tag is required for Twitter Cards.
