### PR TITLE
Add Code of Conduct page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,6 +20,11 @@
             <span class="nav-link-text">Events</span>
           </a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link{% if page.active == 'code-of-conduct' %} active{% endif %}" href="{% link code-of-conduct.md %}">
+            <span class="nav-link-text">Code of Conduct</span>
+          </a>
+        </li>
       </ul>
     </nav>
   </div>

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,39 @@
+---
+active: code-of-conduct
+layout: page
+title: PHP North East Code of Conduct
+---
+All attendees, speakers, sponsors and volunteers at our meet-up are required to agree with the following code of conduct.
+Organizers will enforce this code throughout the event.
+We are expecting cooperation from all participants to help ensuring a safe environment for everybody.
+
+## The Quick Version
+Our meet-up is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices.
+We do not tolerate harassment of meet-up participants in any form.
+Sexual language and imagery is not appropriate for any meet-up venue, including talks, workshops, parties, Twitter and other online media.
+Meet-up participants violating these rules may be sanctioned or expelled from the meet-up at the discretion of the meet-up organizers.
+
+## The Less Quick Version
+Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate  physical contact, and unwelcome sexual attention.
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Sponsors are also subject to the anti-harassment policy.
+In particular, sponsors should not use sexualized images, activities, or other material.
+
+If a participant engages in harassing behavior, the meet-up organizers may take any action they deem appropriate, including warning the offender or expulsion from the meet-up.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of meet-up staff immediately.
+
+Meet-up staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the meet-up. We value your attendance.
+
+We expect participants to follow these rules at meet-up and workshop venues and meet-up related social events.
+
+<footer class="small">
+  <p>
+    Original source and credit:
+    <a href="http://2012.jsconf.us/#/about" rel="external" target="_blank">http://2012.jsconf.us/#/about</a>
+    and
+    <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy" rel="external" target="_blank">The Ada Initiative</a>
+  </p>
+</footer>


### PR DESCRIPTION
Based it on https://github.com/confcodeofconduct/confcodeofconduct.com but replaced any references to “conference” with “meet-up”, and removed portions that mention refunds given we don’t charge attendees to attend our meet-ups.